### PR TITLE
Update the error message

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1687,7 +1687,7 @@ func (a *Agent) AddCheck(check *structs.HealthCheck, chkType *structs.CheckType,
 		}
 
 		if chkType.IsScript() && !a.config.EnableScriptChecks {
-			return fmt.Errorf("Scripts are disabled on this agent; to enable, configure 'enable_script_checks' to true")
+			return fmt.Errorf("Scripts are disabled on this agent; to enable, configure 'enable-script-checks' to true")
 		}
 	}
 


### PR DESCRIPTION
While experimenting with consul agent, I found that one error message was misleading. The error suggests to use enable_script_checks set to true, but the correct parameter to use is enable-script-checks.